### PR TITLE
support code syntax highlighting

### DIFF
--- a/R/decorate_chunk.R
+++ b/R/decorate_chunk.R
@@ -165,6 +165,8 @@ decorate_chunk <- function(chunk_name,
 
   attr(knitted, "orig_chunk_text") <- my_code
 
+  attr(knitted, "engine") <- my_engine
+
   return(knitted)
 
 }

--- a/R/with_flair.R
+++ b/R/with_flair.R
@@ -40,8 +40,8 @@ knit_print.with_flair <- function(x, ...) {
   }
 
   where_sources <- map(x, ~attr(.x, "class")) == "source"
-
-  x[where_sources] <- map(x[where_sources], function(src) prep_source(src, doc_type))
+  src_type = attr(x, "engine")
+  x[where_sources] <- map(x[where_sources], function(src) prep_source(src, doc_type, src_type))
 
   x <- stringr::str_c(unlist(x), collapse = "\n")
 
@@ -56,7 +56,7 @@ knit_print.with_flair <- function(x, ...) {
 #'
 #' @return Properly wrapped text.
 #'
-prep_source <- function(x, doc_type = "unknown") {
+prep_source <- function(x, doc_type = "unknown", src_type = "unknown") {
 
   x <- stringr::str_trim(x) %>%
     stringr::str_replace_all("(?<=\\s) ", "&nbsp;")
@@ -87,7 +87,7 @@ prep_source <- function(x, doc_type = "unknown") {
 
   } else if (doc_type == "html_document") {
 
-    x <- paste0("<pre class='prettyprint'>", txt_tocode(x), "</pre>")
+    x <- paste0("<pre class='prettyprint ", src_type, "'>", txt_tocode(x), "</pre>")
 
   } else if (doc_type == "ioslides_presentation") {
 


### PR DESCRIPTION
addresses #5. This PR adds the name of the engine to flair's code output. This seems to allow highlightjs to do syntax highlighting. I'm not too familiar with how flair and knitr are doing things though, so happy to modify / fix :).

``````
---
title: "test"
output: html_document
---

```{r setup, include=FALSE}
knitr::opts_chunk$set(echo = TRUE)

library(flair)
```

```{r test}
out <- abs(-1)
a <- "a"
```

```{r}
decorate("test") %>%
  flair("-1")

```

``````

![image](https://user-images.githubusercontent.com/2574498/99724248-58915780-2a81-11eb-8723-aa1a23240121.png)

![image](https://user-images.githubusercontent.com/2574498/99724272-60e99280-2a81-11eb-9029-9928ab80b5c9.png)

