### PR TITLE
Use consistent labels for flaired chunks

### DIFF
--- a/R/decorate_chunk.R
+++ b/R/decorate_chunk.R
@@ -54,8 +54,21 @@ decorate_chunk <- function(chunk_name,
 
     my_opts <- as.list(attributes(try_chunk$result)$chunk_opts)
 
-    # labels mess up knit_child
+    # Avoid knitr's duplicate chunk label error by appending "-flaired" to the
+    # chunk label before rendering with knit_child
+    my_label <- paste0(my_opts[["label"]], "-flaired")
+    # If the same chunk is decorated twice, or if the user by chance has labeled
+    # a chunk of the same name plys "-flaired", add a random string to ensure
+    # uniqueness
+    if (my_label %in% knitr::all_labels()) {
+      random <- sample(c(0:9, letters), 7, replace = TRUE)
+      random <- paste(random, collapse = "")
+      my_label <- paste0(my_label, "-", random)
+    }
+    # Remove the label from the chunk options. Required for properly forming
+    # my_code below.
     my_opts <- within(my_opts, rm(label))
+
 
   } else if (is_live) {  # If that failed, try the editor pull
 
@@ -140,12 +153,12 @@ decorate_chunk <- function(chunk_name,
 
       if (length(my_opts) > 1) {
 
-        my_code <- paste0("```{", my_engine, ", ",
+        my_code <- paste0("```{", my_engine, " ", my_label, ", ",
                           toString(list_to_strings(my_opts)),
                           "}\n", my_code, "\n```")
       } else {
 
-        my_code <- paste0("```{", my_engine, "}\n", my_code, "\n```")
+        my_code <- paste0("```{", my_engine,  " ", my_label, "}\n", my_code, "\n```")
 
       }
 

--- a/R/decorate_chunk.R
+++ b/R/decorate_chunk.R
@@ -67,7 +67,7 @@ decorate_chunk <- function(chunk_name,
     }
     # Remove the label from the chunk options. Required for properly forming
     # my_code below.
-    my_opts <- within(my_opts, rm(label))
+    my_opts <- within(my_opts, rm("label"))
 
 
   } else if (is_live) {  # If that failed, try the editor pull
@@ -145,7 +145,7 @@ decorate_chunk <- function(chunk_name,
       } else {
 
         my_engine <- my_opts[["engine"]]
-        my_opts <- within(my_opts, rm(engine))
+        my_opts <- within(my_opts, rm("engine"))
 
       }
 

--- a/R/decorate_chunk.R
+++ b/R/decorate_chunk.R
@@ -58,7 +58,7 @@ decorate_chunk <- function(chunk_name,
     # chunk label before rendering with knit_child
     my_label <- paste0(my_opts[["label"]], "-flaired")
     # If the same chunk is decorated twice, or if the user by chance has labeled
-    # a chunk of the same name plys "-flaired", add a random string to ensure
+    # a chunk of the same name plus "-flaired", add a random string to ensure
     # uniqueness
     if (my_label %in% knitr::all_labels()) {
       random <- sample(c(0:9, letters), 7, replace = TRUE)


### PR DESCRIPTION
Thanks for this great package. I really liked how @sciencificity combined flair with workflowr to share her [R4DS exercise solutions](https://sciencificity.github.io/R4DS_study_exams/).

However, I noticed that one of the workflowr features was missing. Typically below each figure, workflowr inserts a button with a table of past versions of the figure file. These are missing in https://sciencificity.github.io/R4DS_study_exams/ch1_ggplot.html

I did some investigating, and I think this is because flair creates a new unlabeled chunk to knit with `knit_child()`. Since this name is not constant, when workflowr searches the Git log for past versions of that figure file, it can't find them.

To address this, this PR gives each chunk a consistent label by appending `-flaired` to the existing chunk label. And in the case where the same source chunk is decorated more than once (like in the vignette), each chunk is additionally assigned a random string to ensure the labels are unique. This is fine for workflowr since the table of past versions of the figure would still be included the first time the source chunk was decorated.

Please let me know if you are interested in this PR. I'm happy to make adjustments to the strategy and also add tests.

Below is an example with a plot hook that demonstrates how the labels are applied.

````
---
title: flair with plot hook
output: html_document
---

```{r setup}
library(flair)
library(knitr)
custom_plot_hook <- function(x, options) {
  note <- sprintf("<small>The plot '%s' was created on %s</small>",
                  options$label, Sys.Date())
  c(knitr::hook_plot_md(x, options), "\n", note)
}
knit_hooks$set(plot = custom_plot_hook)
```

```{r example}
plot(1:10)
```

```{r example-with-flair, include=FALSE}
plot(1:10)
```

```{r decorate, echo=FALSE}
decorate_chunk("example-with-flair")
```

```{r decorate-2, echo=FALSE}
decorate_chunk("example-with-flair")
```

````

And here is an example of the edge case where the user already labeled a chunk with the same name that flair was going to automatically name the decorated chunk passed to `knit_child()`. In this case, it automatically adds the random string to ensure the label is unique.

````
---
title: flair with plot hook
output: html_document
---

```{r setup}
library(flair)
library(knitr)
custom_plot_hook <- function(x, options) {
  note <- sprintf("<small>The plot '%s' was created on %s</small>",
                  options$label, Sys.Date())
  c(knitr::hook_plot_md(x, options), "\n", note)
}
knit_hooks$set(plot = custom_plot_hook)
```

```{r example-with-flair, include=FALSE}
plot(1:10)
```

```{r example-with-flair-flaired}
# Just happened to name this chunk exactly like the auto-generated chunk would be
```

````