### PR TITLE
Change repo user on installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can install the development version from
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("kbodwin/flair")
+devtools::install_github("r-for-educators/flair")
 ```
 
 (Note that only the development version of `flair` will work with R 4.0.)


### PR DESCRIPTION
For installation step, I noticed the user repo has changed which should now be `r-for-educators` to avoid any potential confusion.